### PR TITLE
Update regarding invalid characters in keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The result is:
 
 ### Basic structure
 
-The configuration document starts with a simple object. Key names can only contain alphanumeric characters and '_' with the '$' prefix reserved
+The configuration document starts with a simple object. Key names can only contain alphanumeric characters, '.', '-', and '_'. The '$' prefix reserved
 for special directives. Values can contain any non-object value (e.g. strings, numbers, booleans) as well as arrays.
 
 ```json

--- a/lib/store.js
+++ b/lib/store.js
@@ -11,6 +11,8 @@ const Boom = require('boom');
 
 const internals = {};
 
+const validKeyChars = '[\\w.\\-]+';
+
 exports = module.exports = internals.Store = function (document) {
 
     this.load(document || {});
@@ -43,7 +45,7 @@ internals.Store.prototype._get = function (key, criteria, applied) {
 
     const path = [];
     if (key !== '/') {
-        const invalid = key.replace(/\/(\w+)/g, ($0, $1) => {
+        const invalid = key.replace(new RegExp(`/(${validKeyChars})`, 'g'), ($0, $1) => {
 
             path.push($1);
             return '';
@@ -328,6 +330,11 @@ internals.Store.validate = function (node, path) {
             }
         }
         else {
+            // Invalid key character(s)
+            if (!(new RegExp(`^${validKeyChars}$`).test(key))) {
+                return error('Invalid character in key ' + key);
+            }
+
             found.key = true;
             const value = node[key];
             const err4 = internals.Store.validate(value, path + '/' + key);

--- a/test/store.js
+++ b/test/store.js
@@ -107,6 +107,14 @@ const tree = {
         ],
         $default: 6
     },
+    'dot.separated': {
+        $filter: 'env',
+        production: { animal: 'platypus' }
+    },
+    'with-hyphen': {
+        $filter: 'env',
+        production: { animal: 'aardvark' }
+    },
     $meta: {
         something: 'else'
     }
@@ -155,6 +163,8 @@ describe('get()', () => {
     get('/ab', 5, { random: { 1: 11 } });
     get('/ab', 5, { random: { 1: 19 } });
     get('/ab', 6, { random: { 1: 29 } });
+    get('/dot.separated', { animal: 'platypus' }, { env: 'production' });
+    get('/with-hyphen', { animal: 'aardvark' }, { env: 'production' });
 
     it('fails on invalid key', (done) => {
 
@@ -268,6 +278,14 @@ describe('validate()', () => {
         const err = Confidence.Store.validate({ key: { $value: { $b: 5 } } });
         expect(err.message).to.equal('Unknown $ directive $b');
         expect(err.path).to.equal('/key/$value');
+        done();
+    });
+
+    it('fails on invalid key character', (done) => {
+
+        const err = Confidence.Store.validate({ key: { 'foo%bar': 5 } });
+        expect(err.message).to.equal('Invalid character in key foo%bar');
+        expect(err.path).to.equal('/key');
         done();
     });
 


### PR DESCRIPTION
- Add support for allowing '.' & '-' in key names.  
- Report invalid characters in keys upon store initialization.

We ran into this issue where we were unknowingly using disallowed characters in our keys and the config was failing 'silently' (i.e. it _was_ returning `undefined` on `.get` but otherwise not alerting us to the error of our ways 😄 )